### PR TITLE
fix: config.json에서 필요없는 qr url 제거

### DIFF
--- a/config.json
+++ b/config.json
@@ -97,7 +97,6 @@
         "font_size": 30
     },
     "qr": {
-        "url": "https://www.google.com",
         "preview_width": 300,
         "preview_height": 300,
         "x": 800,


### PR DESCRIPTION
### config.json

qr_url을 서버에서 받아오므로 json에서 제거