### PR TITLE
fix: 리더기에서도 qr url 없앰

### DIFF
--- a/kiosk-builder-app/config_editor.py
+++ b/kiosk-builder-app/config_editor.py
@@ -514,11 +514,6 @@ class ConfigEditor(QMainWindow):
         
         self.qr_fields = {}
         
-        # URL 필드
-        url_edit = QLineEdit(self.config["qr"]["url"])
-        qr_layout.addRow("URL:", url_edit)
-        self.qr_fields["url"] = url_edit
-        
         # 미리보기 영역 위치 및 크기 설정
         preview_width_spin = QSpinBox()
         preview_width_spin.setRange(0, 1000)


### PR DESCRIPTION
### config_editor.py

qr url을 GET으로 받아와서 QR코드를 만드는 방식이라
qr[url]을 하드코딩하는 항목 삭제