### PR TITLE
fix: 키보드 탭 관련 버그 수정 (배경, 키보드, 폰트, 미리보기)

### DIFF
--- a/components/virtual_keyboard.py
+++ b/components/virtual_keyboard.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import QWidget, QGridLayout, QPushButton, QVBoxLayout, QSizePolicy
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QFont
+from PySide6.QtGui import QFont, QPalette, QColor, QPainter, QBrush, QPen
 from components.hangul_composer import HangulComposer
 from config import config
 
@@ -36,7 +36,7 @@ class VirtualKeyboard(QWidget):
         self.setWindowFlags(
             Qt.WindowType.Tool | Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint
         )
-        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        # WA_TranslucentBackground 제거 - bg_color 스타일시트가 적용되지 않는 문제 해결
         self.initUI()
         self.update_keyboard_labels()
 
@@ -45,14 +45,12 @@ class VirtualKeyboard(QWidget):
     def initUI(self):
         self.layout = QVBoxLayout()
         self.layout.setSpacing(5)
-        self.setStyleSheet(f"""
-        VirtualKeyboard {{
-            background-color: {config["keyboard"]["bg_color"]};
-            border: {config["keyboard"]["border_width"]}px solid {config["keyboard"]["border_color"]};
-            border-radius: {config["keyboard"]["border_radius"]}px;
-            padding: {config["keyboard"]["padding"]}px;
-        }}
-        """)
+
+        # 배경색 설정값 저장 (paintEvent에서 사용)
+        self._bg_color = QColor(config["keyboard"]["bg_color"])
+        self._border_color = QColor(config["keyboard"]["border_color"])
+        self._border_width = config["keyboard"]["border_width"]
+        self._border_radius = config["keyboard"]["border_radius"]
             
         self.keys = [
             ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
@@ -317,3 +315,21 @@ class VirtualKeyboard(QWidget):
         # 색상 코드가 #RRGGBB 형식이라고 가정
         r, g, b = int(color[1:3], 16), int(color[3:5], 16), int(color[5:7], 16)
         return f'#{max(0, r-30):02X}{max(0, g-30):02X}{max(0, b-30):02X}'
+
+    def paintEvent(self, event):
+        """배경색과 테두리를 직접 그리기"""
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+
+        # 배경 그리기
+        painter.setBrush(QBrush(self._bg_color))
+        painter.setPen(QPen(self._border_color, self._border_width))
+        painter.drawRoundedRect(
+            self._border_width // 2,
+            self._border_width // 2,
+            self.width() - self._border_width,
+            self.height() - self._border_width,
+            self._border_radius,
+            self._border_radius
+        )
+        painter.end()

--- a/kiosk-builder-app/ui/components/live_preview.py
+++ b/kiosk-builder-app/ui/components/live_preview.py
@@ -774,15 +774,21 @@ class TextPreviewWidget(LivePreviewWidget):
         """텍스트 요소의 미리보기 좌표 경계 사각형 반환"""
         preview_x = int(elem['x'] / self._scale) + self._render_offset.x()
         preview_y = int(elem['y'] / self._scale) + self._render_offset.y()
-        font_size_preview = int(elem['font_size'] / self._scale)
 
-        # 텍스트 폭 대략 계산 (글자당 0.6 * font_size)
-        text_width = int(len(elem['text']) * font_size_preview * 0.6) + 20
-        text_height = font_size_preview + 10
+        # QFontMetrics를 사용하여 정확한 텍스트 크기 계산
+        font = QFont()
+        if elem.get('font_path') and os.path.exists(elem['font_path']):
+            font.setFamily(elem['font_path'])
+        font.setPointSize(int(elem['font_size'] / self._scale))
 
+        metrics = QFontMetrics(font)
+        text_width = metrics.horizontalAdvance(elem['text']) + 10
+        text_height = metrics.height() + 5
+
+        # 좌상단 기준 사각형 (실제 화면 setGeometry와 동일한 기준)
         return QRect(
-            preview_x - 5,
-            preview_y - font_size_preview,
+            preview_x,
+            preview_y,
             text_width,
             text_height
         )
@@ -830,7 +836,16 @@ class TextPreviewWidget(LivePreviewWidget):
             preview_x = int(elem['x'] / self._scale) + self._render_offset.x()
             preview_y = int(elem['y'] / self._scale) + self._render_offset.y()
 
-            painter.drawText(preview_x, preview_y, elem['text'])
+            # QFontMetrics를 사용하여 텍스트 크기 계산
+            metrics = QFontMetrics(font)
+            text_width = metrics.horizontalAdvance(elem['text'])
+            text_height = metrics.height()
+
+            # QLabel.setGeometry와 동일한 동작을 위해 QRect 기반 drawText 사용
+            # 키오스크에서 QLabel의 (x, y)는 위젯 좌상단 위치이므로,
+            # drawText도 QRect의 좌상단에서 시작하도록 함
+            text_rect = QRect(preview_x, preview_y, text_width + 10, text_height + 5)
+            painter.drawText(text_rect, Qt.AlignLeft | Qt.AlignVCenter, elem['text'])
 
             # 선택된 텍스트에 경계선 및 리사이즈 핸들 표시
             if elem['id'] == self._selected_text_id and elem.get('resizable', True):

--- a/printer_utils/device_functions.py
+++ b/printer_utils/device_functions.py
@@ -124,9 +124,31 @@ def set_surface_properties(device_handle, orientation="portrait"):
 
     return surface_properties
 
+def get_font_family_name(font_path):
+    """
+    TTF 파일에서 실제 폰트 패밀리 이름을 추출하는 함수
+    예: Chosun.ttf -> "조선100년체"
+    """
+    try:
+        from PySide6.QtGui import QFontDatabase
+
+        font_id = QFontDatabase.addApplicationFont(str(font_path))
+        if font_id != -1:
+            families = QFontDatabase.applicationFontFamilies(font_id)
+            if families:
+                return families[0]
+
+        # 찾지 못한 경우 파일명 반환
+        return Path(font_path).stem
+    except Exception as e:
+        print(f"폰트 이름 추출 실패: {e}")
+        return Path(font_path).stem
+
+
 def load_font(font_path):
     """
     지정된 TTF 폰트를 로드하여 사용 가능하게 만드는 함수
+    반환값: 실제 폰트 패밀리 이름 (예: "조선100년체")
     """
     font_path = Path(font_path).resolve()  # 절대 경로 변환
     font_path_wchar = ctypes.c_wchar_p(str(font_path))  # ctypes를 사용하여 문자열 변환
@@ -140,8 +162,10 @@ def load_font(font_path):
         print(f"❌ 폰트 로드 실패: {font_path}")
         return None
 
-    # print(f"✅ 폰트 로드 성공: {font_path}")
-    return Path(font_path).stem  # 폰트 파일명(확장자 제외)을 반환
+    # TTF 파일에서 실제 폰트 패밀리 이름 추출
+    font_name = get_font_family_name(font_path)
+    # print(f"✅ 폰트 로드 성공: {font_path} -> {font_name}")
+    return font_name
 
 def draw_text(device_handle, page, panel, x, y, font_name, font_size, font_style, text):
     """

--- a/screens/text_input_screen.py
+++ b/screens/text_input_screen.py
@@ -44,6 +44,17 @@ class TextInputScreen(QWidget):
             self.setupBackground()
             self._background_initialized = True
             self._last_language = current_lang
+
+        # 키보드 표시 및 입력 필드 초기화
+        if self.keyboard:
+            self.keyboard.show()
+        if self.active_input:
+            self.active_input.setFocus()
+
+        # 이전 텍스트 클리어
+        for input_field in self.text_inputs:
+            input_field.clear()
+
         super().showEvent(event)
 
     def _cleanupBackground(self):
@@ -156,9 +167,14 @@ class TextInputScreen(QWidget):
     def setupBackground(self):
         background_file = None
 
+        # 디버그: 현재 언어 상태 출력
+        print(f"[TextInputScreen] setupBackground 호출 - 현재 언어: {language_manager.current_language}")
+        print(f"[TextInputScreen] 언어 기능 활성화: {language_manager.is_enabled()}")
+
         # 언어 선택 모드가 활성화된 경우 언어별 배경 먼저 확인
         if language_manager.is_enabled():
             lang_path = language_manager.get_background_path(2)  # text input screen = index 2
+            print(f"[TextInputScreen] 언어별 배경 경로: {lang_path}")
             if lang_path:
                 background_file = lang_path
 
@@ -174,6 +190,8 @@ class TextInputScreen(QWidget):
                 if os.path.exists(file_path):
                     background_file = file_path
                     break
+
+        print(f"[TextInputScreen] 최종 배경 파일: {background_file}")
 
         if background_file is None:
             # 모든 파일이 없는 경우 빈 배경 사용
@@ -267,17 +285,6 @@ class TextInputScreen(QWidget):
             }
         """)
         self.close_button.clicked.connect(self.main_window.closeApplication)
-    
-    def showEvent(self, event):
-        # When screen becomes visible, make sure keyboard is shown
-        if self.keyboard:
-            self.keyboard.show()
-        if self.active_input:
-            self.active_input.setFocus()
-            
-        # Clear any previous text
-        for input_field in self.text_inputs:
-            input_field.clear()
     
     def hideEvent(self, event):
         # When screen is hidden, hide the keyboard


### PR DESCRIPTION
  ## Summary
  TextInputScreen(키보드 탭) 관련 컴포넌트의 버그 4건을 수정합니다.

  ## 수정 내용

  ### 1. TextInputScreen 배경이 로드되지 않는 문제
  - **증상**: 텍스트 입력 화면 진입 시 배경 이미지가 표시되지 않음
  - **원인**: showEvent 로직 중복으로 인한 오류
  - **해결**: 두 개의 showEvent를 하나로 병합
  - **관련 파일**: `screens/text_input_screen.py`

  ### 2. VirtualKeyboard 배경색이 적용되지 않는 문제
  - **증상**: config.json에서 keyboard.bg_color를 설정했는데 배경이 투명하게 표시됨
  - **원인**: WA_TranslucentBackground 속성이 배경을 강제로 투명하게 만들고, 스타일시트의 background-color가 child widget으로 동작할 때 제대로 적용되지 않음
  - **해결**: paintEvent를 오버라이드하여 배경색과 테두리를 직접 그리도록 수정
  - **관련 파일**: `components/virtual_keyboard.py`

  ### 3. 폰트가 제대로 인쇄되지 않는 문제
  - **증상**: text_input 아이템의 output_font 설정 후 인쇄 시 폰트 미적용
  - **원인**: load_font() 함수가 TTF 파일명(예: "Chosun")을 반환했으나, 실제 시스템에서는 폰트 패밀리 이름(예: "조선100년체")이 필요함
  - **해결**: get_font_family_name() 함수를 추가하여 QFontDatabase를 통해 TTF 파일에서 실제 폰트 패밀리 이름을 추출
  - **관련 파일**: `printer_utils/device_functions.py`

  ### 4. 미리보기 텍스트 위치가 실제 키오스크와 일치하지 않는 문제
  - **증상**: 빌더에서 설정한 텍스트 위치와 실제 키오스크에서 표시되는 위치가 다름
  - **원인**: drawText(x, y) 방식은 y 좌표가 baseline(하단) 기준이나, 실제 키오스크의 QLabel은 좌상단 기준으로 배치됨
  - **해결**: drawText(QRect, alignment) 방식으로 변경하여 좌상단 기준으로 텍스트 배치
  - **관련 파일**: `kiosk-builder-app/ui/components/live_preview.py`