### PR TITLE
feat: 프레임 화면 UX 개선 및 버그 수정

### DIFF
--- a/kiosk-builder-app/ui/screens/config_editor/frame_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/frame_tab.py
@@ -97,6 +97,7 @@ class FrameTab(BaseTab):
         # 초기 미리보기 업데이트
         self._update_screen_preview()
         self._update_thumbnail_grid()
+        self._update_print_preview()
 
     # ═══════════════════════════════════════════════════════════════
     # 탭 1: 화면 설정

--- a/kiosk-builder-app/ui/screens/config_editor/frame_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/frame_tab.py
@@ -1438,9 +1438,35 @@ class FrameTab(BaseTab):
         self._update_screen_preview()
 
     def remove_frame_from_list(self):
-        """선택한 테두리를 목록에서 삭제"""
+        """선택한 테두리를 목록 및 파일에서 삭제"""
         current_item = self.frame_list.currentItem()
         if current_item:
+            from PySide6.QtWidgets import QMessageBox
+            import os
+
+            frame_filename = current_item.text()
+            frame_path = os.path.join("resources", "frames", frame_filename)
+
+            # 삭제 확인 대화상자
+            reply = QMessageBox.question(
+                self, "테두리 삭제",
+                f"'{frame_filename}' 테두리를 삭제하시겠습니까?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No
+            )
+
+            if reply != QMessageBox.Yes:
+                return
+
+            # 실제 파일 삭제
+            if os.path.exists(frame_path):
+                try:
+                    os.remove(frame_path)
+                except Exception as e:
+                    QMessageBox.warning(self, "오류", f"파일 삭제 실패: {e}")
+                    return
+
+            # 목록에서 삭제
             row = self.frame_list.row(current_item)
             self.frame_list.takeItem(row)
 

--- a/screens/frame_screen.py
+++ b/screens/frame_screen.py
@@ -41,8 +41,28 @@ class FrameScreen(QWidget):
             self.setupBackground()
             self._background_initialized = True
             self._last_language = current_lang
-        # 촬영된 사진 표시 (파일 생성 지연 문제 해결)
+        # 프레임 선택 상태 초기화 (항상 첫 번째부터 시작)
+        self.current_frame_index = -1  # 다음 버튼 누르면 0번 프레임부터
+        self.selected_frame = None
+
+        # 촬영된 사진 표시 (프레임 미적용 상태)
         self.showCapturedPhoto()
+
+        # 페이지 인디케이터 초기화 (모두 비활성화)
+        if hasattr(self, 'page_indicators'):
+            for indicator in self.page_indicators:
+                indicator.setStyleSheet("color: #666; font-size: 16px;")
+
+        # 캐러셀 버튼 초기화 (모두 체크 해제)
+        if hasattr(self, 'carousel_buttons'):
+            for btn in self.carousel_buttons:
+                btn.setChecked(False)
+
+        # 그리드 버튼 초기화 (모두 체크 해제)
+        if hasattr(self, 'grid_buttons'):
+            for btn in self.grid_buttons:
+                btn.setChecked(False)
+
         super().showEvent(event)
         event.accept()
 


### PR DESCRIPTION

  ## Summary
  프레임 선택 화면의 사용자 경험을 개선하고 관련 버그를 수정합니다.

  ## Changes

  ### 프레임 화면 진입 시 선택 상태 초기화
  - `current_frame_index`를 -1로 초기화하여 다음 버튼 클릭 시 첫 번째 프레임부터 시작
  - `selected_frame`을 None으로 초기화하여 프레임 미적용 상태로 표시
  - 페이지 인디케이터, 캐러셀 버튼, 그리드 버튼 모두 비활성화 상태로 초기화
  - 다시 촬영 후 재진입 시에도 항상 첫 번째 프레임부터 시작하도록 수정

  ### 테두리 삭제 시 실제 파일도 함께 삭제
  - 선택한 항목 삭제 시 `resources/frames` 디렉토리에서 파일도 삭제
  - 삭제 전 확인 대화상자 표시

  ### 프레임 탭 인쇄설정 미리보기 초기 표시 문제 수정
  - `init_ui`에서 `_update_print_preview()` 호출 추가