### PR TITLE
fix: ProcessScreen 배경화면 및 빌더 앱 미리보기 문제 수정

### DIFF
--- a/kiosk-builder-app/ui/screens/config_editor/processing_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/processing_tab.py
@@ -371,6 +371,13 @@ class ProcessingTab(BaseTab):
         """화면 미리보기 업데이트"""
         from PySide6.QtGui import QColor
 
+        # 모니터 크기
+        try:
+            monitor_width = self.config["screen_size"]["width"]
+            monitor_height = self.config["screen_size"]["height"]
+        except KeyError:
+            monitor_width, monitor_height = 1080, 1920
+
         # 텍스트 정보 수집
         phrase = self.process_fields.get("phrase")
         x_field = self.process_fields.get("x")
@@ -398,6 +405,7 @@ class ProcessingTab(BaseTab):
             else:
                 bg_path = FileHandler.resolve_background_path(PROCESSING_SCREEN_KEY, lang=None)
 
+            self.screen_preview_screen.set_original_size(monitor_width, monitor_height)
             self.screen_preview_screen.set_background(bg_path, QColor("#ffffff"))
             self.screen_preview_screen.set_card_border(True, QColor("#333333"), 2)
             self.screen_preview_screen.clear_texts()
@@ -419,6 +427,7 @@ class ProcessingTab(BaseTab):
         # 텍스트 설정 탭의 미리보기 위젯 업데이트
         if self.screen_preview_text:
             bg_path = FileHandler.resolve_background_path(PROCESSING_SCREEN_KEY)
+            self.screen_preview_text.set_original_size(monitor_width, monitor_height)
             self.screen_preview_text.set_background(bg_path)
             self.screen_preview_text.clear_texts()
 

--- a/screens/process_screen.py
+++ b/screens/process_screen.py
@@ -23,7 +23,14 @@ class ProcessScreen(QWidget):
         self.setupUI()
 
     def showEvent(self, event):
-        """화면이 표시될 때 배경 초기화 (언어 변경 시 갱신)"""
+        """화면이 표시될 때 배경 초기화 및 프린터 스레드 시작"""
+        # 앱이 종료 중이면 무시 (cleanup 중 showEvent 호출 방지)
+        if hasattr(self.main_window, 'is_closing') and self.main_window.is_closing:
+            print("[ProcessScreen] 앱 종료 중 - showEvent 무시")
+            return
+
+        print(f"[ProcessScreen] showEvent 호출됨!")
+
         current_lang = language_manager.current_language
 
         # 배경이 초기화되지 않았거나 언어가 변경된 경우 배경 갱신
@@ -32,6 +39,10 @@ class ProcessScreen(QWidget):
             self.setupBackground()
             self._background_initialized = True
             self._last_language = current_lang
+
+        # 프린터 스레드 시작
+        self._startPrinterThread()
+
         super().showEvent(event)
 
     def _cleanupBackground(self):
@@ -187,13 +198,8 @@ class ProcessScreen(QWidget):
 
         return process_label
         
-    def showEvent(self, event):
-        # 앱이 종료 중이면 무시 (cleanup 중 showEvent 호출 방지)
-        if hasattr(self.main_window, 'is_closing') and self.main_window.is_closing:
-            print("[ProcessScreen] 앱 종료 중 - showEvent 무시")
-            return
-
-        print(f"[ProcessScreen] showEvent 호출됨!")
+    def _startPrinterThread(self):
+        """프린터 스레드 시작"""
         # PrinterThread가 이미 실행 중인지 확인
         if self.printer_thread is None or not self.printer_thread.isRunning():
             # 프린터 스레드 생성


### PR DESCRIPTION
  ## Summary
  ProcessScreen과 빌더 앱 발급중 탭의 버그 수정

  ## Changes

  ### ProcessScreen 배경화면 미표시 수정
  - 증상: Process 화면 진입 시 배경 이미지가 표시되지 않음
  - 해결: `showEvent` 메서드가 두 번 정의되어 배경 초기화 로직이 무시되고 있었음. 프린터 스레드 로직을 `_startPrinterThread()`로 분리하고 하나의 `showEvent`로 통합
  - 수정 파일: `screens/process_screen.py`

  ### 빌더 앱 발급중 탭 미리보기 크기 미반영 수정
  - 증상: 발급중 탭 미리보기가 다른 탭들과 다르게 세로형으로 고정 표시됨 (디스플레이 탭 모니터 크기 설정 무시)
  - 해결: `_update_screen_preview`에 `set_original_size()` 호출이 누락되어 있었음. 모니터 크기 가져오는 로직과 `set_original_size()` 호출 추가
  - 수정 파일: `kiosk-builder-app/ui/screens/config_editor/processing_tab.py`