### PR TITLE
fix: 빌더 앱 미리보기 기능 개선 및 버그 수정

### DIFF
--- a/kiosk-builder-app/ui/components/live_preview.py
+++ b/kiosk-builder-app/ui/components/live_preview.py
@@ -5,7 +5,7 @@
 """
 from PySide6.QtWidgets import QWidget, QLabel, QVBoxLayout
 from PySide6.QtCore import Signal, Qt, QPoint, QRect, QSize
-from PySide6.QtGui import QMouseEvent, QPainter, QPixmap, QColor, QPen, QBrush, QFont, QFontMetrics, QPainterPath
+from PySide6.QtGui import QMouseEvent, QPainter, QPixmap, QColor, QPen, QBrush, QFont, QFontMetrics, QPainterPath, QFontDatabase
 import os
 
 
@@ -694,6 +694,39 @@ class TextPreviewWidget(LivePreviewWidget):
         self._text_resize_start_size = 0
         self._text_resize_start_pos = QPoint()
 
+        # 폰트 패밀리 캐시 (font_path -> font_family_name)
+        self._font_family_cache = {}
+
+    def _get_font_family(self, font_path: str) -> str:
+        """폰트 파일 경로에서 폰트 패밀리 이름 반환 (캐시 사용)"""
+        if not font_path:
+            return None
+
+        # 파일 이름만 있으면 전체 경로 조합 (키오스크와 동일한 방식)
+        if not os.path.exists(font_path):
+            from utils.file_handler import get_resources_base_path
+            base_path = get_resources_base_path()
+            full_path = os.path.join(base_path, "resources", "font", font_path)
+            if os.path.exists(full_path):
+                font_path = full_path
+            else:
+                return None
+
+        # 캐시 확인
+        if font_path in self._font_family_cache:
+            return self._font_family_cache[font_path]
+
+        # 키오스크와 동일한 방식으로 폰트 로드
+        font_id = QFontDatabase.addApplicationFont(font_path)
+        if font_id != -1:
+            families = QFontDatabase.applicationFontFamilies(font_id)
+            if families:
+                font_family = families[0]
+                self._font_family_cache[font_path] = font_family
+                return font_family
+
+        return None
+
     def add_text(self, element_id: str, text: str, x: int, y: int,
                  font_path: str = None, font_size: int = 24,
                  color: QColor = None, draggable: bool = True,
@@ -777,13 +810,14 @@ class TextPreviewWidget(LivePreviewWidget):
 
         # QFontMetrics를 사용하여 정확한 텍스트 크기 계산
         font = QFont()
-        if elem.get('font_path') and os.path.exists(elem['font_path']):
-            font.setFamily(elem['font_path'])
+        font_family = self._get_font_family(elem.get('font_path'))
+        if font_family:
+            font.setFamily(font_family)
         font.setPointSize(int(elem['font_size'] / self._scale))
 
         metrics = QFontMetrics(font)
-        text_width = metrics.horizontalAdvance(elem['text']) + 10
-        text_height = metrics.height() + 5
+        text_width = metrics.horizontalAdvance(elem['text'])
+        text_height = metrics.height()
 
         # 좌상단 기준 사각형 (실제 화면 setGeometry와 동일한 기준)
         return QRect(
@@ -823,10 +857,11 @@ class TextPreviewWidget(LivePreviewWidget):
         painter.setRenderHint(QPainter.TextAntialiasing)
 
         for elem in self._text_elements:
-            # 폰트 설정
+            # 폰트 설정 (키오스크와 동일한 방식)
             font = QFont()
-            if elem['font_path'] and os.path.exists(elem['font_path']):
-                font.setFamily(elem['font_path'])
+            font_family = self._get_font_family(elem.get('font_path'))
+            if font_family:
+                font.setFamily(font_family)
             font.setPointSize(int(elem['font_size'] / self._scale))
 
             painter.setFont(font)
@@ -844,7 +879,7 @@ class TextPreviewWidget(LivePreviewWidget):
             # QLabel.setGeometry와 동일한 동작을 위해 QRect 기반 drawText 사용
             # 키오스크에서 QLabel의 (x, y)는 위젯 좌상단 위치이므로,
             # drawText도 QRect의 좌상단에서 시작하도록 함
-            text_rect = QRect(preview_x, preview_y, text_width + 10, text_height + 5)
+            text_rect = QRect(preview_x, preview_y, text_width, text_height)
             painter.drawText(text_rect, Qt.AlignLeft | Qt.AlignVCenter, elem['text'])
 
             # 선택된 텍스트에 경계선 및 리사이즈 핸들 표시

--- a/kiosk-builder-app/ui/components/live_preview.py
+++ b/kiosk-builder-app/ui/components/live_preview.py
@@ -774,15 +774,21 @@ class TextPreviewWidget(LivePreviewWidget):
         """텍스트 요소의 미리보기 좌표 경계 사각형 반환"""
         preview_x = int(elem['x'] / self._scale) + self._render_offset.x()
         preview_y = int(elem['y'] / self._scale) + self._render_offset.y()
-        font_size_preview = int(elem['font_size'] / self._scale)
 
-        # 텍스트 폭 대략 계산 (글자당 0.6 * font_size)
-        text_width = int(len(elem['text']) * font_size_preview * 0.6) + 20
-        text_height = font_size_preview + 10
+        # QFontMetrics를 사용하여 정확한 텍스트 크기 계산
+        font = QFont()
+        if elem.get('font_path') and os.path.exists(elem['font_path']):
+            font.setFamily(elem['font_path'])
+        font.setPointSize(int(elem['font_size'] / self._scale))
 
+        metrics = QFontMetrics(font)
+        text_width = metrics.horizontalAdvance(elem['text']) + 10
+        text_height = metrics.height() + 5
+
+        # 좌상단 기준 사각형 (실제 화면 setGeometry와 동일한 기준)
         return QRect(
-            preview_x - 5,
-            preview_y - font_size_preview,
+            preview_x,
+            preview_y,
             text_width,
             text_height
         )
@@ -830,7 +836,16 @@ class TextPreviewWidget(LivePreviewWidget):
             preview_x = int(elem['x'] / self._scale) + self._render_offset.x()
             preview_y = int(elem['y'] / self._scale) + self._render_offset.y()
 
-            painter.drawText(preview_x, preview_y, elem['text'])
+            # QFontMetrics를 사용하여 텍스트 크기 계산
+            metrics = QFontMetrics(font)
+            text_width = metrics.horizontalAdvance(elem['text'])
+            text_height = metrics.height()
+
+            # QLabel.setGeometry와 동일한 동작을 위해 QRect 기반 drawText 사용
+            # 키오스크에서 QLabel의 (x, y)는 위젯 좌상단 위치이므로,
+            # drawText도 QRect의 좌상단에서 시작하도록 함
+            text_rect = QRect(preview_x, preview_y, text_width + 10, text_height + 5)
+            painter.drawText(text_rect, Qt.AlignLeft | Qt.AlignVCenter, elem['text'])
 
             # 선택된 텍스트에 경계선 및 리사이즈 핸들 표시
             if elem['id'] == self._selected_text_id and elem.get('resizable', True):

--- a/kiosk-builder-app/ui/screens/config_editor/basic_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/basic_tab.py
@@ -666,6 +666,7 @@ class BasicTab(BaseTab):
         fields = self.image_item_fields[0]
         position_size = fields["position_size"]
         position_size.set_values(x=0, y=0, width=card_width, height=card_height)
+        self.update_card_preview()
         self.request_real_time_update()
 
     def _center_image_frame(self):
@@ -686,6 +687,7 @@ class BasicTab(BaseTab):
 
         position_size.set_x(int(center_x))
         position_size.set_y(int(center_y))
+        self.update_card_preview()
         self.request_real_time_update()
 
     def _fit_image_width(self):
@@ -700,6 +702,7 @@ class BasicTab(BaseTab):
         position_size = fields["position_size"]
         position_size.set_x(0)
         position_size.set_width(card_width)
+        self.update_card_preview()
         self.request_real_time_update()
 
     def _fit_image_height(self):
@@ -714,6 +717,7 @@ class BasicTab(BaseTab):
         position_size = fields["position_size"]
         position_size.set_y(0)
         position_size.set_height(card_height)
+        self.update_card_preview()
         self.request_real_time_update()
 
     def _on_image_position_changed(self, x, y):

--- a/kiosk-builder-app/ui/screens/config_editor/complete_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/complete_tab.py
@@ -270,7 +270,7 @@ class CompleteTab(BaseTab):
         self.complete_fields["font"] = font_edit
 
         browse_button = QPushButton("찾기...")
-        browse_button.clicked.connect(lambda checked: FileHandler.browse_font_file(self, font_edit))
+        browse_button.clicked.connect(lambda checked: FileHandler.browse_font_file(self, font_edit, self._update_screen_preview))
         font_layout.addWidget(browse_button)
 
         text_layout.addRow("폰트:", font_layout)

--- a/kiosk-builder-app/ui/screens/config_editor/complete_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/complete_tab.py
@@ -229,6 +229,7 @@ class CompleteTab(BaseTab):
         self.screen_preview_screen = TextPreviewWidget(preview_size=DEFAULT_PREVIEW_SIZE)
         self.screen_preview_screen.set_card_border(True, QColor("#333333"), 2)
         self.screen_preview_screen.position_changed.connect(self._on_text_position_changed)
+        self.screen_preview_screen.text_size_changed.connect(self._on_text_size_changed)
         self._zoomable_screen_preview = ZoomablePreviewWidget(self.screen_preview_screen)
         preview_layout.addWidget(self._zoomable_screen_preview, 0, Qt.AlignCenter)
 
@@ -336,6 +337,7 @@ class CompleteTab(BaseTab):
 
         self.screen_preview_text = TextPreviewWidget(preview_size=DEFAULT_PREVIEW_SIZE)
         self.screen_preview_text.position_changed.connect(self._on_text_position_changed)
+        self.screen_preview_text.text_size_changed.connect(self._on_text_size_changed)
         self._zoomable_text_preview = ZoomablePreviewWidget(self.screen_preview_text)
         preview_layout.addWidget(self._zoomable_text_preview, 0, Qt.AlignCenter)
 
@@ -509,6 +511,15 @@ class CompleteTab(BaseTab):
             self.complete_fields['x'].blockSignals(False)
             self.complete_fields['y'].blockSignals(False)
 
+            self.request_real_time_update()
+
+    def _on_text_size_changed(self, element_id: str, new_size: int):
+        """드래그로 텍스트 크기 변경 시 호출"""
+        if element_id == "complete_text":
+            self.complete_fields['font_size'].blockSignals(True)
+            self.complete_fields['font_size'].setValue(new_size)
+            self.complete_fields['font_size'].blockSignals(False)
+            self._update_screen_preview()
             self.request_real_time_update()
 
     def update_ui(self, config):

--- a/kiosk-builder-app/ui/screens/config_editor/keyboard_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/keyboard_tab.py
@@ -1238,7 +1238,7 @@ class KeyboardTab(BaseTab):
             font_layout.addWidget(output_font_edit, 1)
             browse_btn = QPushButton("찾기")
             browse_btn.setFixedWidth(50)
-            browse_btn.clicked.connect(lambda checked, edit=output_font_edit: FileHandler.browse_font_file(self, edit))
+            browse_btn.clicked.connect(lambda checked, edit=output_font_edit: FileHandler.browse_font_file(self, edit, self._update_card_preview))
             font_layout.addWidget(browse_btn)
             item_layout.addRow("폰트:", font_layout)
             fields["output_font"] = output_font_edit
@@ -1352,7 +1352,7 @@ class KeyboardTab(BaseTab):
             font_edit = QLineEdit(item_data.get("font", ""))
             font_layout.addWidget(font_edit, 1)
             browse_btn = QPushButton("찾기...")
-            browse_btn.clicked.connect(lambda checked, edit=font_edit: FileHandler.browse_font_file(self, edit))
+            browse_btn.clicked.connect(lambda checked, edit=font_edit: FileHandler.browse_font_file(self, edit, self._update_card_preview))
             font_layout.addWidget(browse_btn)
             item_layout.addRow("폰트:", font_layout)
             fields["font"] = font_edit

--- a/kiosk-builder-app/ui/screens/config_editor/keyboard_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/keyboard_tab.py
@@ -1514,22 +1514,23 @@ class KeyboardTab(BaseTab):
         # 카드 테두리 표시 (인쇄 영역 경계)
         self.card_preview.set_card_border(True, QColor("#333333"), 3)
 
-        # 사용자 입력 텍스트 인쇄 위치 (실제 텍스트로 렌더링)
+        # 사용자 입력 텍스트 인쇄 위치 (바운딩 박스로 표시)
         input_colors = [QColor("#E53935"), QColor("#1E88E5"), QColor("#7B1FA2"),
                         QColor("#FB8C00"), QColor("#5D4037")]
         for i, fields in enumerate(self.print_input_item_fields):
             if "print_pos" in fields:
                 pos = fields["print_pos"]
                 x, y = pos.get_x(), pos.get_y()
+                w, h = pos.get_width(), pos.get_height()
 
                 # 표시할 텍스트 (placeholder 또는 label 사용)
-                display_text = f"(입력{i+1})"
+                display_text = f"입력{i+1}"
                 if i < len(self.text_input_item_fields):
                     screen_fields = self.text_input_item_fields[i]
                     if "placeholder" in screen_fields and screen_fields["placeholder"].text():
                         display_text = screen_fields["placeholder"].text()
                     elif "label" in screen_fields and screen_fields["label"].text():
-                        display_text = f"({screen_fields['label'].text()})"
+                        display_text = screen_fields["label"].text()
 
                 # 폰트 크기
                 font_size = fields.get("output_font_size")
@@ -1539,54 +1540,39 @@ class KeyboardTab(BaseTab):
                 font_color = fields.get("output_font_color")
                 color_val = QColor(font_color.color) if font_color else input_colors[i % len(input_colors)]
 
-                # 폰트 경로
-                font_path = fields.get("output_font")
-                font_path_val = font_path.text() if font_path else ""
-
-                self.card_preview.add_text(
+                self.card_preview.add_element(
                     f"print_input_{i}",
-                    display_text,
-                    x, y,
-                    font_path=font_path_val,
-                    font_size=font_size_val,
+                    QRect(x, y, w, h),
                     color=color_val,
                     draggable=True,
-                    resizable=True
+                    resizable=True,
+                    label=display_text
                 )
 
-        # 고정 텍스트 (실제 텍스트로 렌더링)
+        # 고정 텍스트 (바운딩 박스로 표시)
         fixed_colors = [QColor("#43A047"), QColor("#00897B"), QColor("#00ACC1"),
                         QColor("#D81B60"), QColor("#757575")]
         for i, fields in enumerate(self.text_item_fields):
             if "pos" in fields:
                 pos = fields["pos"]
                 x, y = pos.get_x(), pos.get_y()
+                w, h = pos.get_width(), pos.get_height()
 
                 # 표시할 텍스트
                 content = fields.get("content")
                 display_text = content.text() if content and content.text() else f"텍스트{i+1}"
 
-                # 폰트 크기
-                font_size = fields.get("font_size")
-                font_size_val = font_size.value() if font_size else 16
-
                 # 폰트 색상
                 font_color = fields.get("font_color")
                 color_val = QColor(font_color.color) if font_color else fixed_colors[i % len(fixed_colors)]
 
-                # 폰트 경로
-                font_path = fields.get("font")
-                font_path_val = font_path.text() if font_path else ""
-
-                self.card_preview.add_text(
+                self.card_preview.add_element(
                     f"fixed_text_{i}",
-                    display_text,
-                    x, y,
-                    font_path=font_path_val,
-                    font_size=font_size_val,
+                    QRect(x, y, w, h),
                     color=color_val,
                     draggable=True,
-                    resizable=True
+                    resizable=True,
+                    label=display_text
                 )
 
         self.request_real_time_update()

--- a/kiosk-builder-app/ui/screens/config_editor/keyboard_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/keyboard_tab.py
@@ -796,8 +796,8 @@ class KeyboardTab(BaseTab):
         special_group.addLayout(special_grid)
         settings_layout.addWidget(special_group)
 
-        # 4. 입력 제한 (접이식, 기본 접힘)
-        limit_group = CollapsibleGroupBox("입력 글자 수 제한", collapsed=True)
+        # 4. 입력 제한 (접이식)
+        limit_group = CollapsibleGroupBox("입력 글자 수 제한", collapsed=False)
         limit_grid = QGridLayout()
         limit_grid.setSpacing(8)
 

--- a/kiosk-builder-app/ui/screens/config_editor/processing_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/processing_tab.py
@@ -112,6 +112,7 @@ class ProcessingTab(BaseTab):
         self.screen_preview_screen = TextPreviewWidget(preview_size=DEFAULT_PREVIEW_SIZE)
         self.screen_preview_screen.set_card_border(True, QColor("#333333"), 2)
         self.screen_preview_screen.position_changed.connect(self._on_text_position_changed)
+        self.screen_preview_screen.text_size_changed.connect(self._on_text_size_changed)
         self._zoomable_screen_preview = ZoomablePreviewWidget(self.screen_preview_screen)
         preview_layout.addWidget(self._zoomable_screen_preview, 0, Qt.AlignCenter)
 
@@ -218,6 +219,7 @@ class ProcessingTab(BaseTab):
         self.screen_preview_text = TextPreviewWidget(preview_size=DEFAULT_PREVIEW_SIZE)
         self.screen_preview_text.set_card_border(True, QColor("#333333"), 2)  # 검은 테두리 추가
         self.screen_preview_text.position_changed.connect(self._on_text_position_changed)
+        self.screen_preview_text.text_size_changed.connect(self._on_text_size_changed)
         self._zoomable_text_preview = ZoomablePreviewWidget(self.screen_preview_text)
         preview_layout.addWidget(self._zoomable_text_preview, 0, Qt.AlignCenter)
 
@@ -412,7 +414,7 @@ class ProcessingTab(BaseTab):
                     font_size=font_size,
                     color=QColor(font_color_str),
                     draggable=True,
-                    resizable=False
+                    resizable=True
                 )
             self.screen_preview_screen.update()
 
@@ -432,7 +434,7 @@ class ProcessingTab(BaseTab):
                     font_size=font_size,
                     color=QColor(font_color_str),
                     draggable=True,
-                    resizable=False
+                    resizable=True
                 )
             self.screen_preview_text.update()
 
@@ -458,6 +460,17 @@ class ProcessingTab(BaseTab):
             # 다른 미리보기 위젯도 동기화
             self._update_screen_preview()
             self.request_real_time_update()
+
+    def _on_text_size_changed(self, element_id: str, new_size: int):
+        """드래그로 텍스트 크기 변경 시 호출"""
+        if element_id == "process_text":
+            font_size_field = self.process_fields.get("font_size")
+            if font_size_field and hasattr(font_size_field, 'setValue'):
+                font_size_field.blockSignals(True)
+                font_size_field.setValue(new_size)
+                font_size_field.blockSignals(False)
+                self._update_screen_preview()
+                self.request_real_time_update()
 
     def _browse_and_update_background(self):
         """배경화면 파일 선택 및 업데이트"""

--- a/kiosk-builder-app/ui/screens/config_editor/processing_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/processing_tab.py
@@ -156,7 +156,7 @@ class ProcessingTab(BaseTab):
 
         # 폰트 파일 선택 버튼 추가
         browse_button = QPushButton("찾기...")
-        browse_button.clicked.connect(lambda checked: FileHandler.browse_font_file(self, font_edit))
+        browse_button.clicked.connect(lambda checked: FileHandler.browse_font_file(self, font_edit, self._update_screen_preview))
         font_layout.addWidget(browse_button)
 
         text_layout.addRow("폰트:", font_layout)

--- a/kiosk-builder-app/ui/screens/config_editor/qr_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/qr_tab.py
@@ -493,7 +493,7 @@ class QRTab(BaseTab):
             monitor_width, monitor_height = 1080, 1920
 
         self.qr_position_input.set_values(x=0, y=0, width=monitor_width, height=monitor_height)
-        self.request_real_time_update()
+        self._update_qr_preview()
 
     def _center_qr_frame(self):
         """QR 코드를 모니터의 중앙에 정렬합니다."""
@@ -511,7 +511,7 @@ class QRTab(BaseTab):
 
         self.qr_position_input.set_x(center_x)
         self.qr_position_input.set_y(center_y)
-        self.request_real_time_update()
+        self._update_qr_preview()
 
     def _fit_qr_width(self):
         """QR 코드 넓이를 모니터 넓이에 맞춥니다 (높이 유지)."""
@@ -522,7 +522,7 @@ class QRTab(BaseTab):
 
         self.qr_position_input.set_x(0)
         self.qr_position_input.set_width(monitor_width)
-        self.request_real_time_update()
+        self._update_qr_preview()
 
     def _fit_qr_height(self):
         """QR 코드 높이를 모니터 높이에 맞춥니다 (넓이 유지)."""
@@ -533,7 +533,7 @@ class QRTab(BaseTab):
 
         self.qr_position_input.set_y(0)
         self.qr_position_input.set_height(monitor_height)
-        self.request_real_time_update()
+        self._update_qr_preview()
 
     def _fill_image_frame(self):
         """업로드된 이미지를 카드 크기에 맞게 채웁니다."""
@@ -656,7 +656,8 @@ class QRTab(BaseTab):
             qr_rect,
             color=QColor("cyan"),
             label="QR 코드",
-            draggable=True
+            draggable=True,
+            resizable=True
         )
 
         self.request_real_time_update()

--- a/kiosk-builder-app/ui/screens/config_editor/splash_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/splash_tab.py
@@ -230,7 +230,7 @@ class SplashTab(BaseTab):
         font_layout.addWidget(font_edit, 1)
         self.splash_fields["font"] = font_edit
         browse_btn = QPushButton("찾기...")
-        browse_btn.clicked.connect(lambda: FileHandler.browse_font_file(self, font_edit))
+        browse_btn.clicked.connect(lambda: FileHandler.browse_font_file(self, font_edit, self._update_screen_preview))
         font_layout.addWidget(browse_btn)
         text_layout.addRow("폰트:", font_layout)
 

--- a/kiosk-builder-app/utils/file_handler.py
+++ b/kiosk-builder-app/utils/file_handler.py
@@ -413,8 +413,14 @@ class FileHandler:
                 line_edit.setText(display_name)
     
     @staticmethod
-    def browse_font_file(parent, line_edit):
-        """폰트 파일 선택 다이얼로그"""
+    def browse_font_file(parent, line_edit, on_changed=None):
+        """폰트 파일 선택 다이얼로그
+
+        Args:
+            parent: 부모 위젯
+            line_edit: 파일명을 표시할 QLineEdit
+            on_changed: 폰트 변경 시 호출할 콜백 함수
+        """
         base_path = get_resources_base_path()
         resources_font_path = os.path.join(base_path, "resources", "font")
         file_path, _ = QFileDialog.getOpenFileName(
@@ -487,6 +493,10 @@ class FileHandler:
                 # 이미 리소스 폴더 내부에 있는 경우 파일명만 사용
                 file_name = os.path.basename(file_path)
                 line_edit.setText(file_name)
+
+            # 콜백 호출
+            if on_changed:
+                on_changed()
 
     @staticmethod
     def browse_frame_file(parent, line_edit):

--- a/printer_utils/printer_thread.py
+++ b/printer_utils/printer_thread.py
@@ -216,16 +216,20 @@ class PrinterThread(QThread):
                 # 텍스트 그리기 (여러 개)
                 for text_info in self.texts:
                     # 폰트 로드 (중복 로드 방지)
-                    font_path = f"resources/font/{text_info['font_name']}"
-                    if font_path not in loaded_fonts:
-                        font_name = load_font(font_path)
-                        if font_name is None:
-                            # self.error.emit(f"폰트 로드 실패: {text_info['font_name']}")
-                            font_name = "맑은 고딕"
-                            # return
-                        loaded_fonts[font_path] = font_name
+                    font_name_config = text_info['font_name']
+
+                    # 폰트명이 비어있으면 기본 폰트 사용
+                    if not font_name_config:
+                        font_name = "맑은 고딕"
                     else:
-                        font_name = loaded_fonts[font_path]
+                        font_path = f"resources/font/{font_name_config}"
+                        if font_path not in loaded_fonts:
+                            font_name = load_font(font_path)
+                            if font_name is None:
+                                font_name = "맑은 고딕"
+                            loaded_fonts[font_path] = font_name
+                        else:
+                            font_name = loaded_fonts[font_path]
 
                     # 색상 변환 (문자열 -> 16진수 정수)
                     if isinstance(text_info["font_color"], str):


### PR DESCRIPTION
  ## Summary
  빌더 앱의 미리보기 관련 버그 수정 및 UX 개선

  ## Changes

  ### 1. 미리보기 텍스트 위치 수정 (6998116)
  - **증상:** 미리보기 텍스트 위치가 실제 키오스크와 다르게 표시됨. (0,0) 위치에서 텍스트가 화면 밖으로 나감
  - **해결:** `drawText(x, baseline)` 대신 `drawText(QRect, alignment)` 사용, QFontMetrics로 정확한 텍스트 크기 계산
  - **파일:** `ui/components/live_preview.py`

  ### 2. 미리보기 폰트 로딩 개선 (2124221)
  - **증상:** 폰트 찾기 버튼 클릭 시 미리보기가 즉시 업데이트되지 않음. 폰트 로딩 방식이 키오스크와 달라 표시 불일치
  - **해결:** `QFontDatabase.addApplicationFont()` 사용, 폰트 패밀리 캐시 추가, on_changed 콜백으로 즉시 업데이트
  - **파일:** `ui/components/live_preview.py`, `utils/file_handler.py`, `splash_tab.py`, `processing_tab.py`, `complete_tab.py`, `keyboard_tab.py`

  ### 3. 고정 이미지 위치 버튼 미리보기 업데이트 (e039dba)
  - **증상:** 채우기/가운데/넓이맞춤/높이맞춤 버튼 클릭 시 값은 변경되지만 미리보기 미갱신
  - **해결:** 각 메서드에 `update_card_preview()` 호출 추가
  - **파일:** `basic_tab.py`

  ### 4. 키보드 탭 입력 글자 수 제한 섹션 기본 펼침 (367d662)
  - **증상:** 입력 글자 수 제한 섹션이 접혀있어 사용자가 설정을 바로 확인할 수 없음
  - **해결:** `CollapsibleGroupBox` collapsed=False로 변경
  - **파일:** `keyboard_tab.py`

  ### 5. 발급중/발급완료 화면 텍스트 드래그 리사이즈 동기화 (24eb540)
  - **증상:** 미리보기에서 텍스트 크기를 드래그로 조절해도 폰트 크기 입력란이 업데이트되지 않음
  - **해결:** `text_size_changed` 시그널 연결, `_on_text_size_changed` 핸들러 추가, resizable=True 설정
  - **파일:** `processing_tab.py`, `complete_tab.py`

  ### 6. QR 탭 미리보기 크기 조절 및 빠른 정렬 버튼 갱신 (1c65ced)
  - **증상:** QR 코드 크기 조절 불가, 전체/가운데/넓이맞춤/높이맞춤 버튼 클릭 시 미리보기 미갱신
  - **해결:** resizable=True 추가, 정렬 버튼에 `_update_qr_preview()` 호출
  - **파일:** `qr_tab.py`

  ### 7. 키보드 탭 인쇄 미리보기 크기 변경 시 입력란 동기화 (39beb5a)
  - **증상:** 미리보기에서 텍스트 크기 드래그 조절 시 너비/높이 입력란이 업데이트되지 않음
  - **해결:** `add_text()` → `add_element()`로 변경하여 바운딩 박스 및 리사이즈 핸들 활성화
  - **파일:** `keyboard_tab.py`

  ### 8. 폰트명 비어있을 때 오류 수정 (fc3b975)
  - **증상:** 폰트명이 비어있으면 `resources/font/` 디렉토리 자체를 로드하려고 시도하여 오류 발생
  - **해결:** 폰트명이 비어있으면 로드 건너뛰고 기본 폰트 "맑은 고딕" 사용
  - **파일:** `printer_utils/printer_thread.py`