### PR TITLE
fix: 스플래시 언어 버튼 선택 시 다른 버튼 색상 오류 수정

### DIFF
--- a/kiosk-builder-app/ui/components/live_preview.py
+++ b/kiosk-builder-app/ui/components/live_preview.py
@@ -45,9 +45,10 @@ def render_button_element(painter: QPainter, preview_rect: QRect, data: dict):
                         border_radius, border_radius)
     painter.fillPath(path, QBrush(bg_color))
 
-    # 테두리 그리기
+    # 테두리 그리기 (내부 채우기 없이 테두리만)
     if border_width > 0:
         painter.setPen(QPen(border_color, border_width))
+        painter.setBrush(Qt.NoBrush)
         painter.drawPath(path)
 
     # 중앙 정렬 텍스트

--- a/kiosk-builder-app/ui/screens/config_editor/splash_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/splash_tab.py
@@ -348,6 +348,9 @@ class SplashTab(BaseTab):
 
         parent_layout.addWidget(self.lang_tab_widget)
 
+        # 언어 버튼 탭 변경 시 미리보기 업데이트
+        self.lang_tab_widget.currentChanged.connect(self._update_screen_preview)
+
         # 활성화 상태에 따라 탭 위젯 표시/숨김
         self.lang_tab_widget.setVisible(self.lang_enabled_checkbox.isChecked())
 

--- a/kiosk-builder-app/ui/screens/config_editor/splash_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/splash_tab.py
@@ -417,15 +417,11 @@ class SplashTab(BaseTab):
 
     def _add_lang_buttons_to_preview_widget(self, preview_widget):
         """언어 선택 버튼을 특정 미리보기 위젯에 추가 (실제 버튼 스타일)"""
-        # 시그널 연결 (한 번만)
-        try:
-            preview_widget.position_changed.disconnect(self._on_lang_button_position_changed)
-            preview_widget.size_changed.disconnect(self._on_lang_button_size_changed)
-        except (RuntimeError, TypeError):
-            pass
-
-        preview_widget.position_changed.connect(self._on_lang_button_position_changed)
-        preview_widget.size_changed.connect(self._on_lang_button_size_changed)
+        # 시그널 연결 (UniqueConnection으로 중복 연결 방지)
+        preview_widget.position_changed.connect(
+            self._on_lang_button_position_changed, Qt.UniqueConnection)
+        preview_widget.size_changed.connect(
+            self._on_lang_button_size_changed, Qt.UniqueConnection)
 
         # 미리보기 스케일 가져오기
         scale = getattr(preview_widget, '_scale', 1.0)


### PR DESCRIPTION
## Summary
- 미리보기에서 한글 버튼 선택 시 영어 버튼 색상이 파란색으로 변경되는 버그 수정
- `render_button_element`에서 테두리 그리기 전 `setBrush(Qt.NoBrush)` 추가하여 이전 요소의 brush 상태가 다음 요소에 영향 주지 않도록 함
- 언어 버튼 탭 전환 시 미리보기 업데이트 시그널 연결 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)