### PR TITLE
fix: QFont::setPointSize 경고 메시지 수정

### DIFF
--- a/kiosk-builder-app/ui/components/live_preview.py
+++ b/kiosk-builder-app/ui/components/live_preview.py
@@ -813,7 +813,7 @@ class TextPreviewWidget(LivePreviewWidget):
         font_family = self._get_font_family(elem.get('font_path'))
         if font_family:
             font.setFamily(font_family)
-        font.setPointSize(int(elem['font_size'] / self._scale))
+        font.setPointSize(max(1, int(elem['font_size'] / self._scale)))
 
         metrics = QFontMetrics(font)
         text_width = metrics.horizontalAdvance(elem['text'])
@@ -862,7 +862,7 @@ class TextPreviewWidget(LivePreviewWidget):
             font_family = self._get_font_family(elem.get('font_path'))
             if font_family:
                 font.setFamily(font_family)
-            font.setPointSize(int(elem['font_size'] / self._scale))
+            font.setPointSize(max(1, int(elem['font_size'] / self._scale)))
 
             painter.setFont(font)
             painter.setPen(QPen(elem['color']))

--- a/kiosk-builder-app/ui/screens/config_editor/components/card_preview_dialog.py
+++ b/kiosk-builder-app/ui/screens/config_editor/components/card_preview_dialog.py
@@ -841,7 +841,7 @@ class FloatingCardPreviewDialog(QDialog):
     def _get_font(self, font_path: str, font_size: int) -> QFont:
         """폰트 로드 - 경로가 있으면 로드, 없으면 기본 폰트"""
         font = QFont()
-        font.setPointSize(font_size)
+        font.setPointSize(max(1, font_size))
 
         if font_path and os.path.exists(font_path):
             font_id = QFontDatabase.addApplicationFont(font_path)


### PR DESCRIPTION
## Summary
- 폰트 크기가 0 이하가 되지 않도록 `max(1, ...)` 처리 추가
- `QFont::setPointSize: Point size <= 0` 경고 메시지 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)