### PR TITLE
fix: 화면설정 탭에서 키보드 이동 시 키보드 위치 탭 미리보기 동기화

### DIFF
--- a/kiosk-builder-app/ui/screens/config_editor/keyboard_tab.py
+++ b/kiosk-builder-app/ui/screens/config_editor/keyboard_tab.py
@@ -1585,6 +1585,7 @@ class KeyboardTab(BaseTab):
             self.keyboard_position_input.set_x(x)
             self.keyboard_position_input.set_y(y)
             self.keyboard_position_input.block_all_signals(False)
+            self._update_keyboard_pos_preview()  # 키보드 위치 탭 미리보기도 업데이트
         elif element_id.startswith("input_"):
             idx = int(element_id.split("_")[1])
             if idx < len(self.text_input_item_fields) and "screen_pos" in self.text_input_item_fields[idx]:
@@ -1601,6 +1602,7 @@ class KeyboardTab(BaseTab):
             self.keyboard_position_input.block_all_signals(True)
             self.keyboard_position_input.set_values(x=x, y=y, width=width, height=height)
             self.keyboard_position_input.block_all_signals(False)
+            self._update_keyboard_pos_preview()  # 키보드 위치 탭 미리보기도 업데이트
         elif element_id.startswith("input_"):
             idx = int(element_id.split("_")[1])
             if idx < len(self.text_input_item_fields) and "screen_pos" in self.text_input_item_fields[idx]:


### PR DESCRIPTION
## Summary
- 화면설정 탭에서 키보드를 드래그/리사이즈하면 키보드 위치 탭 미리보기도 함께 갱신되도록 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)